### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ 'blacksmith-2vcpu-ubuntu-2204' ]
     name: Java ${{ matrix.Java }} (${{ matrix.os }})
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
     - name: Set up Java
-      uses: useblacksmith/setup-java@v5
+      uses: useblacksmith/setup-java@4ef812391eff6e9737ba13bf0356d0f702877a64  # v5
       with:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v2 -> @ee0669bd...`
- `useblacksmith/setup-java@v5 -> @4ef81239...`


### Why

This repo was flagged as **HIGH** risk: unpinned actions triggered by pull requests allow fork-based supply chain attacks.

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
